### PR TITLE
Modify ActiviesForm.js with CKEditor and more

### DIFF
--- a/src/Components/Activities/ActivitiesForm.js
+++ b/src/Components/Activities/ActivitiesForm.js
@@ -1,30 +1,83 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import { CKEditor } from '@ckeditor/ckeditor5-react';
+import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 import '../FormStyles.css';
 
 const ActivitiesForm = () => {
     const [initialValues, setInitialValues] = useState({
         name: '',
-        description: ''
+        description: '',
+        image: ''
     });
+    // petition === true ? POST : PATCH
+    const [petition, setPetition] = useState();
+    // Error message
+    const [errorName, setErrorName] = useState(false);
+    const [errorImage, setErrorImage] = useState(false);
+    const [errorSendData, setErrorSendData] = useState(false);
+
+    const VALIDATION = {
+        name: /^[a-zA-Z\s]{4,}$/,
+        description: /^$/,
+        image: /\.(jpg|png)$/i
+    }
+
+    useEffect(() => {
+        const OBJECT_VALUE = Object.values(initialValues).filter(data => data !== '');
+        OBJECT_VALUE.length === 0 ? setPetition(true) : setPetition(false);
+        // eslint-disable-next-line react-hooks/exhaustive-deps 
+    }, [])
 
     const handleChange = (e) => {
         if(e.target.name === 'name'){
-            setInitialValues({...initialValues, name: e.target.value})
-        } if(e.target.name === 'description'){
-            setInitialValues({...initialValues, description: e.target.value})
+            setInitialValues({...initialValues, name: e.target.value});
+            VALIDATION.name.test(e.target.value) ? setErrorName(false) : setErrorName(true);
+        } else {
+            setInitialValues({ ...initialValues, image: e.target.value});
+            VALIDATION.image.test(e.target.value) ? setErrorImage(false) : setErrorImage(true);
         }
     }
 
     const handleSubmit = (e) => {
         e.preventDefault();
-        console.log(initialValues);
+        const fetchData = async (values) => {
+            try {
+                if (petition) {
+                    const { data } = await axios.post('/activities/create', values);
+                    console.log(data)
+                } else {
+                    const { data } = await axios.patch(`/activities/:id`, values);
+                    console.log(data)
+                }
+            } catch (error) {
+                console.log(error);
+            }
+        }
+        if (VALIDATION.name.test(initialValues.name) && VALIDATION.image.test(initialValues.image) && !VALIDATION.description.test(initialValues.description)) {
+            fetchData(initialValues);
+        } else {
+            setErrorSendData(true);
+            setTimeout(() => setErrorSendData(false), 2000)
+        }
     }
     
     return (
         <form className="form-container" onSubmit={handleSubmit}>
             <input className="input-field" type="text" name="name" value={initialValues.name} onChange={handleChange} placeholder="Activity Title"></input>
-            <input className="input-field" type="text" name="description" value={initialValues.description} onChange={handleChange} placeholder="Write some activity description"></input>
+            {errorName ? <p>Error, it must only contain letters and a minium length of 3 characters</p> : null}
+            <CKEditor className="input-field" name="description"
+                    editor={ ClassicEditor }
+                    data={initialValues.description}
+                    onChange={ ( event, editor ) => {
+                        const data = editor.getData();
+                        setInitialValues({ ...initialValues, description: data});
+                    } }
+                />
+            <input type="file" name="image" onChange={handleChange} />
+            {errorImage ? <p>Error, image must be in .jpg or .png format</p> : null}
             <button className="submit-btn" type="submit">Send</button>
+            {errorSendData ? <p>Error, you must complete all the fields</p> : null}
         </form>
     );
 }


### PR DESCRIPTION
COMO: Usuario administrador
QUIERO: Crear o editar una actividad existente
PARA: Mantener el contenido actualizado

Criterios de aceptacion: En base del formulario de creación existente que contiene los campos Name y Description, agregar el campo Imagen. Para la Descripción, reemplazar el campo de texto por la librería CKEditor. El objetivo es crear un formulario reutilizable para las acciones de edición como de creación. Para esto, deberá poder comportarse de forma diferente según recibe una actividad o no. En el caso de no recibir un objeto de actividad existente, mostrar los campos vacíos y realizar una petición POST al endpoint de creación de novedades (/activities/create). En el caso de recibir un objeto de actividad, completar el formulario con los campos del mismo y realizar una petición PATCH al endpoint de actualización del server (/activities/:id). Este formulario se mostrará en el backoffice tanto en las rutas de creación y edición.

Validaciones:

Name e Image son obligatorios

La imagen deberá tener un formato .jpg o .png

### Summary

- Modify description with CKEditor
- Add field image
- Send data POST or PATCH