### PR TITLE
Modify privateApiService.js

### DIFF
--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -2,14 +2,18 @@ import axios from 'axios';
 
 const config = {
     headers: {
-        Group: 01                //Aqui va el ID del equipo!!
+        Group: 94,              //Aqui va el ID del equipo!!
+        Authorization: 'userToken'          
     }
 }
 
-const Get = () => {
-    axios.get('https://jsonplaceholder.typicode.com/users', config)
-    .then(res => console.log(res))
-    .catch(err => console.log(err))
+const Get = async (route, id, config) => {
+    try {
+        const results = await axios.get(`${route}/${id}`, config);
+        console.log(results.data)
+    } catch (err) {
+        console.log(err.message)
+    }
 }
 
-export default Get
+export default Get;


### PR DESCRIPTION
COMO: Desarrollador
QUIERO: Hacer peticiones GET a los endpoints privados API de forma centralizada
PARA: Estandarizar la logica de la comunicación con el servidor.

Criterios de aceptacion: El método deberá recibir una ruta destino, un id (que puede ser null) el cual debera ser concatenado al final de la url luego de una /, e invocar el método para agregar el encabezado Authorization en base al token del usuario, para generar una petición GET. Agregarlo en privateApiService.js.

### Summary

- Modify Function Get
- Add Authorization to petition GET