### PR TITLE
Modify privateApiService and connect with component Activity

### DIFF
--- a/src/Components/Activities/ActivitiesForm.js
+++ b/src/Components/Activities/ActivitiesForm.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { CKEditor } from '@ckeditor/ckeditor5-react';
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 import '../FormStyles.css';
-
+import getDataActivityForm from "../../Services/privateApiService";
 const ActivitiesForm = () => {
     const [initialValues, setInitialValues] = useState({
         name: '',

--- a/src/Components/Activities/ActivitiesList.js
+++ b/src/Components/Activities/ActivitiesList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import '../CardListStyles.css';
 import Titles from '../Titles/Titles';
-
+import getDataActivityList from "../../Services/privateApiService";
 const ActivitiesList = () => {
     const activitiesMock = [
         {id: 2, name: 'Titulo de prueba', description: 'Descripcion de prueba'},

--- a/src/Components/Activities/Detail/ActivitiesDetail.jsx
+++ b/src/Components/Activities/Detail/ActivitiesDetail.jsx
@@ -2,7 +2,7 @@ import axios from 'axios'
 import React, { useEffect, useState, Fragment } from 'react'
 import Titles from '../../Titles/Titles'
 import ActivitiesContent from './ActivitiesContent'
-
+import getDataActivityDetail from "../../../Services/privateApiService";;
 export default function ActivitiesDetail(props) {
 
     const [content, setContent] = useState()

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -16,4 +16,40 @@ const Get = async (route, id, config) => {
     }
 }
 
+export const getDataActivityDetail = async (route) => {
+    try {
+        const response = await axios.get(`${route}`);
+        return response.data;
+    } catch (error) {
+        return console.log(error);
+    }
+}
+export const getDataActivityForm = async (route) => {
+    try {
+        const response = await axios.get(`${route}`);
+        return response.data;
+    } catch (error) {
+        return console.log(error);
+    }
+}
+
+export const getDataActivityList = async (route) => {
+    try {
+        const response = await axios.get(`${route}`);
+        return response.data;
+    } catch (error) {
+        return console.log(error);
+    }
+}
+
+export const getDataActivityTable = async (route) => {
+    try {
+        const response = await axios.get(`${route}`);
+        return response.data;
+    } catch (error) {
+        return console.log(error);
+    }
+}
+
+
 export default Get;


### PR DESCRIPTION
COMO: Desarrollador
QUIERO: Centralizar las llamadas a la API
PARA: Reutilizar el servicio desde todos los componentes

Criterios de aceptacion: Crear un servicio de Actividades con todos los metodos necesarios para las diferentes peticiones de los componentes de Actividades a la API, utilizando el servicio HTTP base.
Conectar los componentes de Actividades con el servicio creado.

### Summary

- Modify privateApiService with request HTTP from Activity
- Connect apiService with Activities components