### PR TITLE
Create function isConnectedToken in privateApiService

### DIFF
--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -16,4 +16,18 @@ const Get = async (route, id, config) => {
     }
 }
 
+const IsTokenConnected = () => {
+    let token = localStorage.getItem("token");
+    if (token !== null) {
+        let data = {
+            headers: {
+                authorization: `Bearer ${token}`
+            }
+        }
+        return data;
+    } else {
+        return console.log("Error, no hay token")
+    }
+}
+
 export default Get;


### PR DESCRIPTION
COMO: Desarrollador
QUIERO: Configurar el header de las peticiones HTTP
PARA: Estandarizar la seguridad de las mismas

Criterios de aceptacion: Generar un metodo en el servicio de peticiones HTTP privadas, que verifique la existencia del token en el localStorage y que devuelva un objeto Header Authorization con el valor "Bearer " + el token obtenido.

### Summary 

- Create function IsTokenConnected in privateApiService