### PR TITLE
Modify privateApiService with request from News

### DIFF
--- a/src/Components/News/Detail/NewsDetail.jsx
+++ b/src/Components/News/Detail/NewsDetail.jsx
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import React, { useEffect, useState } from 'react'
 import Titles from '../../Titles/Titles'
-
+import getDataNewsDetail from "../../../Services/publicApiService";
 export default function NewsDetail(props) {
 
     const [novedades, setNovedades] = useState()

--- a/src/Components/News/NewsForm.js
+++ b/src/Components/News/NewsForm.js
@@ -3,7 +3,7 @@ import '../../Components/FormStyles.css';
 import categoriesDEMO from './categories.json' //categorias locales hasta tener el endpoint real
 import { CKEditor } from '@ckeditor/ckeditor5-react';
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
-
+import getDataNewsForm from "../../Services/privateApiService";
 const NewsForm = () => {
 
     const [recieveNews, setRecieveNews] = useState(true);

--- a/src/Components/News/NewsList.js
+++ b/src/Components/News/NewsList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import '../CardListStyles.css';
 import Titles from '../Titles/Titles';
-
+import getDataNewsList from "../../Services/privateApiService";
 const NewsList = ( {novedades} ) => {
 
     return (

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -16,4 +16,40 @@ const Get = async (route, id, config) => {
     }
 }
 
+export const getDataNewsDetail = async (route) => {
+    try {
+        const response = axios.get(`${route}`);
+        return response.data;
+    } catch (error) {
+        return console.log(error)
+    }
+}
+
+export const getDataNewsForm = async (route) => {
+    try {
+        const response = axios.get(`${route}`);
+        return response.data;
+    } catch (error) {
+        return console.log(error)
+    }
+}
+
+export const getDataNewsList = async (route) => {
+    try {
+        const response = axios.get(`${route}`);
+        return response.data;
+    } catch (error) {
+        return console.log(error)
+    }
+}
+
+export const getDataNewsTable = async (route) => {
+    try {
+        const response = axios.get(`${route}`);
+        return response.data;
+    } catch (error) {
+        return console.log(error)
+    }
+}
+
 export default Get;


### PR DESCRIPTION
COMO: Desarrollador
QUIERO: Centralizar las llamadas a la API
PARA: Poder reutilizar el servicio desde todos los componentes.

Criterios de aceptacion: Crear un servicio de Novedades con la cantidad de metodos necesarios para las diferentes peticiones de los componentes de Novedades a la API, utilizando el servicio HTTP base.
Conectar los componentes de Novedades con el servicio creado.

### Summary

- Modify privateApiService with request from News