### PR TITLE
Alert petition news

### DIFF
--- a/src/Components/News/Detail/NewsDetail.jsx
+++ b/src/Components/News/Detail/NewsDetail.jsx
@@ -1,9 +1,17 @@
 import axios from 'axios'
 import React, { useEffect, useState } from 'react'
 import Titles from '../../Titles/Titles'
+// import Alert from '../Skeleton/Alert';
+import Alert from "../../Skeleton/Alert";
+// redux
+import { showAlerts } from '../../../features/alert/alertSlice';
+import { useDispatch, useSelector } from 'react-redux'; 
 
 export default function NewsDetail(props) {
-
+    // redux
+    const valueAlert = useSelector(state => state.alert);
+    const dispatch = useDispatch();
+ 
     const [novedades, setNovedades] = useState()
 
     async function getNewsDetail() {
@@ -11,7 +19,7 @@ export default function NewsDetail(props) {
             const {data} = await axios.get('url')
             setNovedades(data)
         } catch(error) {
-            console.log(error)
+            dispatch(showAlerts(true))
         }
     }
 
@@ -22,6 +30,18 @@ export default function NewsDetail(props) {
             <Titles imagenTitulo={props.imagenDetail} titulo={props.tituloDetail} />
             <img src='novedades.imagen' alt='novedades.alt'/>
             <p>novedades.contenido</p>
+            {valueAlert.showAlert ?  
+                Alert({
+                    showAlert: valueAlert,
+                    title: "Hubo un error!",
+                    text: "Error al realizar peticion desde el servicio",
+                    type: "error",
+                    cancelButton: false,
+                    confirmButtonText: "OK",
+                    cancelButtonText: "Cancel",
+                    showDenyButton: true
+                }) 
+            : null }
         </div>
     )
 }

--- a/src/Components/News/NewsForm.js
+++ b/src/Components/News/NewsForm.js
@@ -3,8 +3,14 @@ import '../../Components/FormStyles.css';
 import categoriesDEMO from './categories.json' //categorias locales hasta tener el endpoint real
 import { CKEditor } from '@ckeditor/ckeditor5-react';
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
+import Alert from '../Skeleton/Alert';
+// redux
+import { showAlerts } from '../../features/alert/alertSlice';
+import { useDispatch, useSelector } from 'react-redux'; 
 
 const NewsForm = () => {
+    const valueAlert = useSelector(state => state.alert);
+    const dispatch = useDispatch();
 
     const [recieveNews, setRecieveNews] = useState(true);
 
@@ -77,6 +83,7 @@ const NewsForm = () => {
         };
         fetch('/news', requestInit)
             .then((res) => res.text())
+            .catch(error =>  dispatch(showAlerts(true)))
             .then((res) => console.log(res));
 
         console.log(initialValues)
@@ -156,6 +163,18 @@ const NewsForm = () => {
                 <button className="submit-btn" type="submit" > Send </button>
 
             </form>
+            {valueAlert.showAlert ?  
+                Alert({
+                    showAlert: valueAlert,
+                    title: "Hubo un error!",
+                    text: "Error al realizar peticion desde el servicio",
+                    type: "error",
+                    cancelButton: false,
+                    confirmButtonText: "OK",
+                    cancelButtonText: "Cancel",
+                    showDenyButton: true
+                }) 
+            : null }
         </div>
     );
 }

--- a/src/Components/Skeleton/Alert.js
+++ b/src/Components/Skeleton/Alert.js
@@ -1,5 +1,7 @@
-import React, { useState } from "react";
+import React from "react";
 import SweetAlert from "sweetalert2-react";
+import { useDispatch } from 'react-redux'; 
+import { showAlerts } from "../../features/alert/alertSlice";
 
 // ...
 // Types :  success | error | warning | info | question
@@ -13,10 +15,10 @@ const Alert = ({
   cancelButtonText = "Cancel",
   showDenyButton = true,
 }) => {
-  const [show, setShow] = useState(showAlert);
+  const dispatch = useDispatch();
   return (
     <SweetAlert
-      show={show}
+      show={showAlert}
       title={title}
       type={type}
       text={text}
@@ -25,7 +27,7 @@ const Alert = ({
       confirmButtonText={confirmButtonText}
       cancelButtonText={cancelButtonText}
       showDenyButton={showDenyButton}
-      onConfirm={() => setShow(false)}
+      onConfirm={() => dispatch(showAlerts(false))}
     />
   );
 };

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,10 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import counterReducer from '../features/counter/counterSlice';
 import authReducer from '../features/user/userSlice';
-
+import alertReducer from "../features/alert/alertSlice";
 export default configureStore({
   reducer: {
     counter: counterReducer,
     user: authReducer,
+    alert: alertReducer
   },
 });

--- a/src/features/alert/alertSlice.js
+++ b/src/features/alert/alertSlice.js
@@ -1,0 +1,20 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+    showAlert: false
+}
+
+export const alertSlice = createSlice({
+    name: "alert",
+    initialState,
+    reducers: {
+        showAlerts: (state, action) => {
+            state = {showAlert: action.payload};
+            return state;
+        }
+    }
+})
+
+export const { showAlerts } = alertSlice.actions 
+
+export default alertSlice.reducer;


### PR DESCRIPTION
COMO: Usuario
QUIERO: Visualizar errores
PARA: Tener un feedback al realizar una acción

Criterios de aceptacion: Utilizando los componentes reutilizables de alerta, mostrar un error al usuario cuando las peticiones realizadas desde el servicio tengan un error
.
### Summary

- Modify newsDetail.jsx  and NewsForm.js
- Add reducer alert to redux with sweet alert