### PR TITLE
adding protection to private routes with admin role

### DIFF
--- a/src/AppRoutes.js
+++ b/src/AppRoutes.js
@@ -1,24 +1,33 @@
-import React from "react";
+import React from 'react';
 import './App.css';
-import { BrowserRouter, Switch } from "react-router-dom";
-import { PrivateRoute } from "./Components/Routes/PrivateRoute";
-import { PublicRoute } from "./Components/Routes/PublicRoute";
-import { AppPrivateRoutes } from "./Components/Routes/AppPrivateRoutes";
-import { AppPublicRoutes } from "./Components/Routes/AppPublicRoutes";
+import { BrowserRouter, Switch } from 'react-router-dom';
+import { PrivateRoute } from './Components/Routes/PrivateRoute';
+import { PublicRoute } from './Components/Routes/PublicRoute';
+import { AppPrivateRoutes } from './Components/Routes/AppPrivateRoutes';
+import { AppPublicRoutes } from './Components/Routes/AppPublicRoutes';
 
 export const AppRoutes = () => {
+  // realizar llamado a Redux de autenticación creado en tkt OT94-106
+  const user = { logged: true, role: 'administrador' };
 
-   // realizar llamado a Redux de autenticación creado en tkt OT94-106
-    const user = { 'logged': false };
-  
-    return (
-        <BrowserRouter>
-            <div>
-              <Switch>
-                <PrivateRoute path="/backoffice" component={AppPrivateRoutes } isAuthenticated={user.logged} />
-                <PublicRoute  path="/" component={AppPublicRoutes}  isAuthenticated={user.logged} /> 
-              </Switch>
-            </div>
-        </BrowserRouter>
-    )
-}
+  return (
+    <BrowserRouter>
+      <div>
+        <Switch>
+          <PrivateRoute
+            path='/backoffice'
+            component={AppPrivateRoutes}
+            isAuthenticated={user.logged}
+            role={user.role}
+          />
+          <PublicRoute
+            path='/'
+            component={AppPublicRoutes}
+            isAuthenticated={user.logged}
+            role={user.role}
+          />
+        </Switch>
+      </div>
+    </BrowserRouter>
+  );
+};

--- a/src/Components/Routes/PrivateRoute.js
+++ b/src/Components/Routes/PrivateRoute.js
@@ -5,6 +5,7 @@ import { Route, Redirect } from 'react-router-dom';
 
 export const PrivateRoute = ({
   isAuthenticated,
+  role,
   component: Component,
   ...rest
 }) => {
@@ -16,7 +17,11 @@ export const PrivateRoute = ({
       <Route
         {...rest}
         component={(props) =>
-          isAuthenticated ? <Component {...props} /> : <Redirect to='/' />
+          isAuthenticated && role.toLowerCase() === 'administrador' ? (
+            <Component {...props} />
+          ) : (
+            <Redirect to='/' />
+          )
         }
       />
     </>
@@ -25,5 +30,6 @@ export const PrivateRoute = ({
 
 PrivateRoute.propTypes = {
   isAuthenticated: PropTypes.bool.isRequired,
+  role: PropTypes.string.isRequired,
   component: PropTypes.func.isRequired,
 };

--- a/src/Components/Routes/PublicRoute.js
+++ b/src/Components/Routes/PublicRoute.js
@@ -4,6 +4,7 @@ import { Route, Redirect } from 'react-router-dom';
 
 export const PublicRoute = ({
   isAuthenticated,
+  role,
   component: Component,
   ...rest
 }) => {
@@ -11,7 +12,11 @@ export const PublicRoute = ({
     <Route
       {...rest}
       component={(props) =>
-        !isAuthenticated ? <Component {...props} /> : <Redirect to='/backoffice' />
+        !isAuthenticated || role.toLowerCase() !== 'administrador' ? (
+          <Component {...props} />
+        ) : (
+          <Redirect to='/backoffice' />
+        )
       }
     />
   );


### PR DESCRIPTION
Descripción
COMO: Desarrollador
QUIERO: Proteger las rutas del administrador
PARA: Aumentar la seguridad del sitio

Criterios de aceptacion: Agregar lógica para tener seguridad en las rutas del frontend. Es decir, para ingresar a las secciones de gestión del backoffice, el usuario debe tener un rol de administrador. Si intenta ingresar a una ruta a la que no tiene permiso, debe ser redirigido al Home.