### PR TITLE
Create NewsService and connect

### DIFF
--- a/src/Components/News/Detail/NewsDetail.jsx
+++ b/src/Components/News/Detail/NewsDetail.jsx
@@ -2,6 +2,7 @@ import axios from 'axios'
 import React, { useEffect, useState } from 'react'
 import Titles from '../../Titles/Titles'
 import Alert from '../../Skeleton/Alert';
+import { getDataNewsDetail } from '../../../Services/NewsService';
 // redux
 import { showAlerts } from '../../../features/alert/alertSlice';
 import { useDispatch, useSelector } from 'react-redux'; 

--- a/src/Components/News/NewsForm.js
+++ b/src/Components/News/NewsForm.js
@@ -4,6 +4,7 @@ import categoriesDEMO from './categories.json' //categorias locales hasta tener 
 import { CKEditor } from '@ckeditor/ckeditor5-react';
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 import Alert from '../Skeleton/Alert';
+import { getDataNewsForm } from '../../Services/NewsService';
 // redux
 import {showAlerts} from "../../features/alert/alertSlice";
 import { useDispatch, useSelector } from 'react-redux'; 

--- a/src/Components/News/NewsList.js
+++ b/src/Components/News/NewsList.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import '../CardListStyles.css';
 import Titles from '../Titles/Titles';
-
-import getDataNewsTable from "../../Services/privateApiService" //ticket emiliano conectar news con service
+import { getDataNewsList } from '../../Services/NewsService'; //cambie table por List porque es una lista
 
 const NewsList = ({ novedades }) => {
 

--- a/src/Components/News/NewsList2.js
+++ b/src/Components/News/NewsList2.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import MockList from './newsMock.json'
 import './NewsList2.css'
-
+import { getDataNewsTable } from '../../Services/NewsService'
 const NewsList2 = () => {
     return (
         <div className="news-list">

--- a/src/Services/NewsService.js
+++ b/src/Services/NewsService.js
@@ -1,0 +1,37 @@
+import axios from "axios";
+
+export const getDataNewsDetail = async (route) => {
+    try {
+        const response = axios.get(`${route}`);
+        return response.data;
+    } catch (error) {
+        return console.log(error)
+    }
+}
+
+export const getDataNewsForm = async (route) => {
+    try {
+        const response = axios.get(`${route}`);
+        return response.data;
+    } catch (error) {
+        return console.log(error)
+    }
+}
+
+export const getDataNewsList = async (route) => {
+    try {
+        const response = axios.get(`${route}`);
+        return response.data;
+    } catch (error) {
+        return console.log(error)
+    }
+}
+
+export const getDataNewsTable = async (route) => {
+    try {
+        const response = axios.get(`${route}`);
+        return response.data;
+    } catch (error) {
+        return console.log(error)
+    }
+}


### PR DESCRIPTION
COMO: Desarrollador
QUIERO: Centralizar las llamadas a la API
PARA: Poder reutilizar el servicio desde todos los componentes.

Criterios de aceptación: Crear un servicio de Novedades con la cantidad de métodos necesarios para las diferentes peticiones de los componentes de Novedades a la API, utilizando el servicio HTTP base.
Conectar los componentes de Novedades con el servicio creado.

### Summary

- Create NewsService with request and connect to all components of News