### PR TITLE
Modify store and create activityReducer with thunk

### DIFF
--- a/src/Components/Activities/Detail/ActivitiesDetail.jsx
+++ b/src/Components/Activities/Detail/ActivitiesDetail.jsx
@@ -2,9 +2,19 @@ import axios from 'axios'
 import React, { useEffect, useState, Fragment } from 'react'
 import Titles from '../../Titles/Titles'
 import ActivitiesContent from './ActivitiesContent'
+// llamada a Api con redux thunk Activiti
+// import { getListActivities } from '../../../features/activity/activitySlice'
+// import { useDispatch, useSelector } from 'react-redux'
 
 export default function ActivitiesDetail(props) {
-
+    // Llamada a redux thunk funcionando
+    // const dispatch = useDispatch();         
+    // const { listActivities } = useSelector((state) => state.listActivity);
+    // useEffect(() => {
+    //     dispatch(getListActivities("https://jsonplaceholder.typicode.com/users"))
+    // }, [])
+    // console.log(listActivities)
+    
     const [content, setContent] = useState()
 
     async function getActivity() {

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -2,10 +2,13 @@ import { configureStore } from '@reduxjs/toolkit';
 import counterReducer from '../features/counter/counterSlice';
 import authReducer from '../features/user/userSlice';
 import alertReducer from "../features/alert/alertSlice";
+import activityReducer from "../features/activity/activitySlice";
+
 export default configureStore({
   reducer: {
     counter: counterReducer,
     user: authReducer,
-    alert: alertReducer
+    alert: alertReducer,
+    listActivity: activityReducer
   },
 });

--- a/src/features/activity/activitySlice.js
+++ b/src/features/activity/activitySlice.js
@@ -1,0 +1,32 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import axios from "axios";
+
+export const getListActivities = createAsyncThunk (
+    "listActivities/getListActivities",
+    async (dispatch, getState) => {
+        const response = await axios.get(`${dispatch}`)
+        return response.data;
+    }
+);
+
+const activitySlice = createSlice({
+    name: "listActivity",
+    initialState: {
+        listActivities: [],
+        status: null
+    },
+    extraReducers: {
+        [getListActivities.pending]: (state, action) => {
+            state.status = "loading";
+        }, 
+        [getListActivities.fulfilled]: (state, action) => {
+            state.status = "success";
+            state.listActivities = action.payload; 
+        },
+        [getListActivities.rejected]: (state, action) => {
+            state.status = "failed";
+        },
+    },
+}) 
+
+export default activitySlice.reducer;


### PR DESCRIPTION
COMO: Usuario desarrollador
QUIERO: Gestionar el estado de forma centralizada
PARA: Mejorar la calidad y escalabilidad del código

Criterios de aceptacion: Utilizando redux-toolkit, desarrollar un reducer para gestionar el estado de actividades. El mismo deberá tener la acción para renderizar el listado de actividades en su respectivo componente.
La lógica existente de peticiones a la API deberá moverse a thunks asíncronos dentro del reducer.

Utilizar el método createAsyncThunk de Redux Toolkit para la creación de thunks: 
https://redux.js.org/tutorials/essentials/part-5-async-logic#writing-async-thunks

### Summary

- Create activitySlice to get the list of activities with async thunk
- Modify ActivitiesDetail.jsx to see how it work
